### PR TITLE
fix: do not panic on garbage in

### DIFF
--- a/pem.go
+++ b/pem.go
@@ -131,7 +131,7 @@ func GetChainAndKeyFromRawPEM(
 	}
 
 	// If there is a client-facing certificate, try to find its key.
-	if chain.FurthestLeaf.Type == CertTypeClientCert {
+	if chain.FurthestLeaf != nil && chain.FurthestLeaf.Type == CertTypeClientCert {
 		clientKey = FindKeyForCertificate(chain.FurthestLeaf, keys)
 	}
 	return

--- a/sort_plain_test.go
+++ b/sort_plain_test.go
@@ -50,6 +50,21 @@ func TestCertificateSort(t *testing.T) {
 	}
 }
 
+func TestInvalidCaOnly(t *testing.T) {
+	certs := NewRawCerts("invalid ca")
+
+	sortedCerts, key, err := SortCertificates(certs, true)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %s", err)
+	}
+	if len(sortedCerts) != 0 {
+		t.Fatalf("Expected chain length to be 0, got: %d", len(sortedCerts))
+	}
+	if key != nil {
+		t.Fatal("Key was expected to be nil")
+	}
+}
+
 func TestCertificatesWithInvalidCert(t *testing.T) {
 	rawKeys, err := readFiles(filePaths)
 	if err != nil {

--- a/sort_plain_test.go
+++ b/sort_plain_test.go
@@ -12,4 +12,103 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package certsort_test
+package certsort
+
+import (
+	"testing"
+)
+
+var filePaths = []string{
+	"test_data/concat/ca.pem",
+	"test_data/concat/cert.pem",
+	"test_data/concat/key.pem",
+}
+
+// Note that these test are not testing the actual sorting algorithm, but rather the
+// the error or invalid input outcome, which is basically garbage in, garbage out.
+// Makes sure it does not panic or return unexpected results.
+
+func TestCertificateSort(t *testing.T) {
+	rawKeys, err := readFiles(filePaths)
+	if err != nil {
+		t.Fatalf("Error in readFiles: %s", err)
+	}
+
+	certs := NewRawCerts(string(rawKeys[0]))
+	certs = certs.Append(string(rawKeys[1]))
+	certs = certs.Append(string(rawKeys[2]))
+
+	sortedCerts, key, err := SortCertificates(certs, true)
+	if err != nil {
+		t.Fatalf("Error in SortCertificates: %s", err)
+	}
+	if len(sortedCerts) != 6013 {
+		t.Fatalf("Expected chain length to be 3, got: %d", len(sortedCerts))
+	}
+	if key == nil {
+		t.Fatal("Key was expected to be non-nil")
+	}
+}
+
+func TestCertificatesWithInvalidCert(t *testing.T) {
+	rawKeys, err := readFiles(filePaths)
+	if err != nil {
+		t.Fatalf("Error in readFiles: %s", err)
+	}
+	certs := NewRawCerts(string(rawKeys[0]))
+	certs = certs.Append("invald cert")
+	certs = certs.Append(string(rawKeys[2]))
+
+	sortedCerts, key, err := SortCertificates(certs, true)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %s", err)
+	}
+	if len(sortedCerts) != 4817 {
+		t.Fatalf("Expected chain length to be 4817, got: %d", len(sortedCerts))
+	}
+	if key != nil {
+		t.Fatal("Key was expected to be nil")
+	}
+}
+
+func TestCertificatesWithInvalidCa(t *testing.T) {
+	rawKeys, err := readFiles(filePaths)
+	if err != nil {
+		t.Fatalf("Error in readFiles: %s", err)
+	}
+	certs := NewRawCerts("invalid ca")
+	certs = certs.Append(string(rawKeys[1]))
+	certs = certs.Append(string(rawKeys[2]))
+
+	sortedCerts, key, err := SortCertificates(certs, true)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %s", err)
+	}
+	if len(sortedCerts) != 1196 {
+		t.Fatalf("Expected chain length to be 1196, got: %d", len(sortedCerts))
+	}
+	if key == nil {
+		t.Fatal("Key was expected to be non-nil")
+	}
+}
+
+func TestCertificatesWithInvalidKey(t *testing.T) {
+	rawKeys, err := readFiles(filePaths)
+	if err != nil {
+		t.Fatalf("Error in readFiles: %s", err)
+	}
+	certs := NewRawCerts(string(rawKeys[0]))
+	certs = certs.Append(string(rawKeys[1]))
+	certs = certs.Append("invalid key")
+
+	sortedCerts, key, err := SortCertificates(certs, true)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %s", err)
+	}
+	if len(sortedCerts) != 6013 {
+		t.Fatalf("Expected chain length to be 6013, got: %d", len(sortedCerts))
+	}
+	if key != nil {
+		t.Fatal("key was expected to be nil")
+	}
+}


### PR DESCRIPTION
If any bad string is passed, at the moment it would just panic at the furthest leaf check, as it would be nil.

We want to allow garbage in - garbage out for most cases, as the purpose of the lib is not validating the certificates.

